### PR TITLE
UIButton extension fix

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -307,7 +307,7 @@ public extension UITextField {
 
 public extension UIButton {
     func parseIcon() {
-        let text = replaceString((self.titleLabel?.text)! as NSString)
+        let text = replaceString((self.currentTitle)! as NSString)
         self.setAttributedTitle(getAttributedString(text, fontSize: (self.titleLabel?.font!.pointSize)!), forState: .Normal)
     }
 }


### PR DESCRIPTION
Changing button title doesn't break parseIcon() now