### PR TITLE
Ability to set icon color when creating an image

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -57,7 +57,7 @@ public extension UIFont{
 
 public extension UIImage
 {
-    public static func icon(from font: Fonts, code: String, imageSize: CGSize, ofSize size: CGFloat) -> UIImage
+    public static func icon(from font: Fonts, iconColor: UIColor, code: String, imageSize: CGSize, ofSize size: CGFloat) -> UIImage
     {
         let drawText = String.getIcon(from: font, code: code)
         
@@ -65,7 +65,7 @@ public extension UIImage
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = NSTextAlignment.center
         
-		drawText!.draw(in: CGRect(x:0, y:0, width:imageSize.width, height:imageSize.height), withAttributes: [NSFontAttributeName : UIFont.icon(from: font, ofSize: size), NSParagraphStyleAttributeName: paragraphStyle])
+		drawText!.draw(in: CGRect(x:0, y:0, width:imageSize.width, height:imageSize.height), withAttributes: [NSFontAttributeName : UIFont.icon(from: font, ofSize: size), NSParagraphStyleAttributeName: paragraphStyle, NSForegroundColorAttributeName: iconColor])
         
 		let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()

--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -325,7 +325,7 @@ public extension UIBarButtonItem {
 }
 
 public extension UITabBarItem {
-    func icon(from font: Fonts, code: String, imageSize: CGSize, ofSize size: CGFloat) {
-        self.image = UIImage.icon(from: font, code: code, imageSize: imageSize, ofSize: size)
+    func icon(from font: Fonts, code: String, iconColor: UIColor, imageSize: CGSize, ofSize size: CGFloat) {
+        self.image = UIImage.icon(from: font, iconColor: iconColor, code: code, imageSize: imageSize, ofSize: size)
     }
 }

--- a/SwiftIconFont/Classes/SwiftIconTabBarItem.swift
+++ b/SwiftIconFont/Classes/SwiftIconTabBarItem.swift
@@ -13,9 +13,10 @@ class SwiftIconTabBarItem: UITabBarItem {
     @IBInspectable var Icon: String = ""
     @IBInspectable var FontSize: CGFloat = 20.0
     @IBInspectable var ImageSize: CGSize = CGSize(width: 20, height: 20)
+    @IBInspectable var IconColor: UIColor = UIColor.black
     
     override func awakeFromNib() {
-        icon(from: GetFontTypeWithSelectedIcon(Icon), code:GetIconIndexWithSelectedIcon(Icon), imageSize: ImageSize, ofSize: FontSize)
+        icon(from: GetFontTypeWithSelectedIcon(Icon), code:GetIconIndexWithSelectedIcon(Icon), iconColor: IconColor, imageSize: ImageSize, ofSize: FontSize)
     }
 
 }


### PR DESCRIPTION
When creating an image for an icon there was no ability to set the color for the icon. With this modification it's possible to do so now.