### PR TITLE
Get the currentTitle of UIButton from the titleLabel

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -302,7 +302,8 @@ public extension UITextField {
 
 public extension UIButton {
     func parseIcon() {
-        let text = replace(withText: (self.currentTitle)! as NSString)
+        guard let currentTitle = self.titleLabel?.text as? NSString else { return }
+        let text = replace(withText: currentTitle)
         let attrTitle = getAttributedString(text, ofSize: (self.titleLabel?.font!.pointSize)!)
         let all = NSRange(location: 0, length: attrTitle.length)
         attrTitle.addAttribute(NSForegroundColorAttributeName, value: self.currentTitleColor, range: all)


### PR DESCRIPTION
I noticed that if I directly added a icon via `SwiftIconButton` `Icon` `@IBInspectable` and did **not** set a title, I would get an `optional not found` error. This was due to `self.currentTitle` being nil when `parseIcon` was executed.

I changed the code to use `self.titleLabel.text`, which is what the `@IBInspectable` sets. I also wrapped it in the guard statement so it's safer.