### PR TITLE
Fix unicode for transit icon in Material icons

### DIFF
--- a/SwiftIconFont/Classes/MaterialIcon.swift
+++ b/SwiftIconFont/Classes/MaterialIcon.swift
@@ -245,7 +245,7 @@ public let materialIconArr: [String: String] = [
     "directions.railway":"\u{e534}",
     "directions.run":"\u{e566}",
     "directions.subway":"\u{e533}",
-    "directions.transit":"\u{e535}",
+    "directions.transit":"\u{e565}",
     "directions.walk":"\u{e536}",
     "disc.full":"\u{e610}",
     "dns":"\u{e875}",


### PR DESCRIPTION
I was getting subway icon when trying to use transit one.

#### Update from:

![screen shot 2017-03-03 at 10 59 42 am](https://cloud.githubusercontent.com/assets/645452/23553687/a95fa7ca-0000-11e7-9372-7acce8bdcf94.png)

#### To:

![screen shot 2017-03-03 at 11 00 37 am](https://cloud.githubusercontent.com/assets/645452/23553686/a93ba2f8-0000-11e7-8ccc-0e29c103496c.png)


This happened because we're using a old .ttf file. The proper solution is to update `.ttf` file then update all icons unicode characters introducing `traffic` and keeping `transit` as a "subway"-like icon.

As I can't do it right now, just fixed this `transit` icon.