### PR TITLE
Icon image is broken when item button is pressed on iOS11 and iPhone8

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -410,7 +410,9 @@ public extension UIBarButtonItem {
                 }
             }
         }
-        self.setTitleTextAttributes(textAttributes, for: UIControlState())
+        self.setTitleTextAttributes(textAttributes, for: UIControlState.normal)
+        self.setTitleTextAttributes(textAttributes, for: UIControlState.highlighted)
+
         self.title = String.getIcon(from: font, code: code)
     }
 }


### PR DESCRIPTION
![simulator-screen-shot---iphone-8---2017-09-28-at-18 28](https://user-images.githubusercontent.com/2545766/30968322-43dbe606-a4a2-11e7-9f78-9c11398bd90c.png)
