### PR TITLE
Fix enum to lower camel case

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController, UITabBarDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         testLabel1.parseIcon()
-        testLabel2.font = UIFont.icon(from: .FontAwesome, ofSize: 17.0)
+        testLabel2.font = UIFont.icon(from: .fontAwesome, ofSize: 17.0)
         testLabel2.text = String.fontAwesomeIcon("twitter")
         tabbarItem.badgeValue = "1"
         //textField.runtimeParse = true
@@ -31,7 +31,7 @@ class ViewController: UIViewController, UITabBarDelegate {
         tabbar.selectedItem = tabbarItem
         
         let imageView: UIImageView = UIImageView(frame: CGRect(x: 120, y: self.view.frame.size.height - 130, width: 150, height: 50))
-        imageView.setIcon(from: .Octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: nil)
+        imageView.setIcon(from: .octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: nil)
         self.view.addSubview(imageView)
     }
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 ## Fonts
 ````swift
 public enum Fonts: String {
-    case FontAwesome = "FontAwesome"
-    case Iconic = "open-iconic"
-    case Ionicon = "Ionicons"
-    case Octicon = "octicons"
-    case Themify = "themify"
-    case MapIcon = "map-icons"
-    case MaterialIcon = "MaterialIcons-Regular"
+    case fontAwesome = "FontAwesome"
+    case iconic = "open-iconic"
+    case ionicon = "Ionicons"
+    case octicon = "octicons"
+    case themify = "themify"
+    case mapIcon = "map-icons"
+    case materialIcon = "MaterialIcons-Regular"
 }
 ````
 
@@ -103,7 +103,7 @@ The lazy way, just set your UILabel, UITextField, UIButton, UITextView, UIBarBut
 ````swift
 import SwiftIconFont
 
-label.font = UIFont.icon(from: .FontAwesome, ofSize: 50.0)
+label.font = UIFont.icon(from: .fontAwesome, ofSize: 50.0)
 label.text = String.fontAwesomeIcon(code: "twitter")
 ````
 
@@ -113,7 +113,7 @@ label.text = String.fontAwesomeIcon(code: "twitter")
 ````swift
 import SwiftIconFont
 
-twitterBarButton.icon(from: .FontAwesome, code: "twitter", ofSize: 20)
+twitterBarButton.icon(from: .fontAwesome, code: "twitter", ofSize: 20)
 ````
 
 #### UITabBarItem (Without Custom Class)
@@ -121,7 +121,7 @@ twitterBarButton.icon(from: .FontAwesome, code: "twitter", ofSize: 20)
 ````swift
 import SwiftIconFont
 
-twitterTabBarButton.icon(from: .FontAwesome, code: "twitter", imageSize: CGSizeMake(20, 20), ofSize: 20)
+twitterTabBarButton.icon(from: .fontAwesome, code: "twitter", imageSize: CGSizeMake(20, 20), ofSize: 20)
 ````
 
 #### UIImage
@@ -129,7 +129,7 @@ twitterTabBarButton.icon(from: .FontAwesome, code: "twitter", imageSize: CGSizeM
 ````swift
 import SwiftIconFont
 
-let githubLogo = UIImage(from: .Octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: CGSize(width: 150, height: 50))
+let githubLogo = UIImage(from: .octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: CGSize(width: 150, height: 50))
 ````
 
 #### UIImageView
@@ -138,7 +138,7 @@ let githubLogo = UIImage(from: .Octicon, code: "logo-github", textColor: .black,
 import SwiftIconFont
 
 let githubLogoImageView: UIImageView = UIImageView(frame: CGRect(x: 120, y: self.view.frame.size.height - 130, width: 150, height: 50))
-githubLogoImageView.setIcon(from: .Octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: nil)
+githubLogoImageView.setIcon(from: .octicon, code: "logo-github", textColor: .black, backgroundColor: .clear, size: nil)
 ````
 
 ## Author

--- a/SwiftIconFont/Classes/Extensions/SwiftIconFont+String.swift
+++ b/SwiftIconFont/Classes/Extensions/SwiftIconFont+String.swift
@@ -11,19 +11,19 @@ import Foundation
 public extension String {
     public static func getIcon(from font: Fonts, code: String) -> String? {
         switch font {
-        case .FontAwesome:
+        case .fontAwesome:
             return fontAwesomeIcon(code)
-        case .Iconic:
+        case .iconic:
             return fontIconicIcon(code)
-        case .Ionicon:
+        case .ionicon:
             return fontIonIcon(code)
-        case .MapIcon:
+        case .mapIcon:
             return fontMapIcon(code)
-        case .MaterialIcon:
+        case .materialIcon:
             return fontMaterialIcon(code)
-        case .Octicon:
+        case .octicon:
             return fontOcticon(code)
-        case .Themify:
+        case .themify:
             return fontThemifyIcon(code)
         }
     }

--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -17,29 +17,29 @@ public struct SwiftIcon {
 }
 
 public enum Fonts: String {
-    case FontAwesome = "FontAwesome"
-    case Iconic = "open-iconic"
-    case Ionicon = "Ionicons"
-    case Octicon = "octicons"
-    case Themify = "themify"
-    case MapIcon = "map-icons"
-    case MaterialIcon = "MaterialIcons-Regular"
+    case fontAwesome = "FontAwesome"
+    case iconic = "open-iconic"
+    case ionicon = "Ionicons"
+    case octicon = "octicons"
+    case themify = "themify"
+    case mapIcon = "map-icons"
+    case materialIcon = "MaterialIcons-Regular"
     
     var fontName: String {
         switch self {
-        case .FontAwesome:
+        case .fontAwesome:
             return "FontAwesome"
-        case .Iconic:
+        case .iconic:
             return "Icons"
-        case .Ionicon:
+        case .ionicon:
             return "Ionicons"
-        case .Octicon:
+        case .octicon:
             return "octicons"
-        case .Themify:
+        case .themify:
             return "Themify"
-        case .MapIcon:
+        case .mapIcon:
             return "map-icons"
-        case .MaterialIcon:
+        case .materialIcon:
             return "Material Icons"
         }
     }
@@ -73,29 +73,29 @@ func getAttributedString(_ text: NSString, ofSize size: CGFloat) -> NSMutableAtt
             fontCode = (fontCode as NSString).replacingOccurrences(of: "_", with: "-")
         }
         
-        var fontType: Fonts = Fonts.FontAwesome
+        var fontType: Fonts = Fonts.fontAwesome
         var fontArr: [String: String] = ["": ""]
         
         if fontPrefix == "fa" {
-            fontType = Fonts.FontAwesome
+            fontType = Fonts.fontAwesome
             fontArr = fontAwesomeIconArr
         } else if fontPrefix == "ic" {
-            fontType = Fonts.Iconic
+            fontType = Fonts.iconic
             fontArr = iconicIconArr
         } else if fontPrefix == "io" {
-            fontType = Fonts.Ionicon
+            fontType = Fonts.ionicon
             fontArr = ioniconArr
         } else if fontPrefix == "oc" {
-            fontType = Fonts.Octicon
+            fontType = Fonts.octicon
             fontArr = octiconArr
         } else if fontPrefix == "ti" {
-            fontType = Fonts.Themify
+            fontType = Fonts.themify
             fontArr = temifyIconArr
         } else if fontPrefix == "mi" {
-            fontType = Fonts.MapIcon
+            fontType = Fonts.mapIcon
             fontArr = mapIconArr
         } else if fontPrefix == "ma" {
-            fontType = Fonts.MaterialIcon
+            fontType = Fonts.materialIcon
             fontArr = materialIconArr
         }
         
@@ -135,29 +135,29 @@ func getAttributedStringForRuntimeReplace(_ text: NSString, ofSize size: CGFloat
             
             if fontPrefix.utf16.count > 0 && fontCode.utf16.count > 0 {
                 
-                var fontType: Fonts = Fonts.FontAwesome
+                var fontType: Fonts = Fonts.fontAwesome
                 var fontArr: [String: String] = ["": ""]
                 
                 if fontPrefix == "fa" {
-                    fontType = Fonts.FontAwesome
+                    fontType = Fonts.fontAwesome
                     fontArr = fontAwesomeIconArr
                 } else if fontPrefix == "ic" {
-                    fontType = Fonts.Iconic
+                    fontType = Fonts.iconic
                     fontArr = iconicIconArr
                 } else if fontPrefix == "io" {
-                    fontType = Fonts.Ionicon
+                    fontType = Fonts.ionicon
                     fontArr = ioniconArr
                 } else if fontPrefix == "oc" {
-                    fontType = Fonts.Octicon
+                    fontType = Fonts.octicon
                     fontArr = octiconArr
                 } else if fontPrefix == "ti" {
-                    fontType = Fonts.Themify
+                    fontType = Fonts.themify
                     fontArr = temifyIconArr
                 } else if fontPrefix == "mi" {
-                    fontType = Fonts.MapIcon
+                    fontType = Fonts.mapIcon
                     fontArr = mapIconArr
                 } else if fontPrefix == "ma" {
-                    fontType = Fonts.MaterialIcon
+                    fontType = Fonts.materialIcon
                     fontArr = materialIconArr
                 }
                 
@@ -202,7 +202,7 @@ func GetIconIndexWithSelectedIcon(_ icon: String) -> String {
 
 func GetFontTypeWithSelectedIcon(_ icon: String) -> Fonts {
     let text = icon as NSString
-    var fontType: Fonts = Fonts.FontAwesome
+    var fontType: Fonts = Fonts.fontAwesome
     
     for substring in ((text as String).split{$0 == " "}.map(String.init)) {
         var splitArr = ["", ""]
@@ -221,19 +221,19 @@ func GetFontTypeWithSelectedIcon(_ icon: String) -> Fonts {
         
         
         if fontPrefix == "fa" {
-            fontType = Fonts.FontAwesome
+            fontType = Fonts.fontAwesome
         } else if fontPrefix == "ic" {
-            fontType = Fonts.Iconic
+            fontType = Fonts.iconic
         } else if fontPrefix == "io" {
-            fontType = Fonts.Ionicon
+            fontType = Fonts.ionicon
         } else if fontPrefix == "oc" {
-            fontType = Fonts.Octicon
+            fontType = Fonts.octicon
         } else if fontPrefix == "ti" {
-            fontType = Fonts.Themify
+            fontType = Fonts.themify
         } else if fontPrefix == "mi" {
-            fontType = Fonts.MapIcon
+            fontType = Fonts.mapIcon
         } else if fontPrefix == "ma" {
-            fontType = Fonts.MaterialIcon
+            fontType = Fonts.materialIcon
         }
     }
     

--- a/SwiftIconFont/Classes/UI/SwiftIconFontView.swift
+++ b/SwiftIconFont/Classes/UI/SwiftIconFontView.swift
@@ -21,7 +21,7 @@ import UIKit
     
     
     private var iconView = UILabel()
-    private var iconFont = Fonts.FontAwesome
+    private var iconFont = Fonts.fontAwesome
     
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
Fix enum to lower camel case.  Swift API Design Guidelines recommends lowerCamelCase for enum case since Swift3.x.

## Reference
- https://swift.org/documentation/api-design-guidelines/
> Follow case conventions. Names of types and protocols are UpperCamelCase. Everything else is lowerCamelCase.