### PR TITLE
Fixed the question mark is displayed on disabled UIBarButtonItem

### DIFF
--- a/SwiftIconFont/Classes/Extensions/SwiftIconFont+UIBarButtonItem.swift
+++ b/SwiftIconFont/Classes/Extensions/SwiftIconFont+UIBarButtonItem.swift
@@ -23,6 +23,7 @@ public extension UIBarButtonItem {
         }
         self.setTitleTextAttributes(textAttributes, for: UIControlState.normal)
         self.setTitleTextAttributes(textAttributes, for: UIControlState.highlighted)
+        self.setTitleTextAttributes(textAttributes, for: UIControlState.disabled)
         
         self.title = String.getIcon(from: font, code: code)
     }


### PR DESCRIPTION
fixes #85

My problem was solved in this way. Please review it when you have time.
Although CI has failed, I think that it is not caused by changes of this pull request.
Thanks.