### PR TITLE
Make public GetIconIndexWithSelectedIcon and GetFontTypeWithSelectedIcon

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -186,7 +186,7 @@ func getAttributedStringForRuntimeReplace(_ text: NSString, ofSize size: CGFloat
     return attributedString
 }
 
-func GetIconIndexWithSelectedIcon(_ icon: String) -> String {
+public func GetIconIndexWithSelectedIcon(_ icon: String) -> String {
     let text = icon as NSString
     var iconIndex: String = ""
  
@@ -208,7 +208,7 @@ func GetIconIndexWithSelectedIcon(_ icon: String) -> String {
     return iconIndex
 }
 
-func GetFontTypeWithSelectedIcon(_ icon: String) -> Fonts {
+public func GetFontTypeWithSelectedIcon(_ icon: String) -> Fonts {
     let text = icon as NSString
     var fontType: Fonts = Fonts.fontAwesome
     


### PR DESCRIPTION
In my app I fetch data for icons from webservice, I receive for example **fa:file** string for  an icon, I need to display this icon into UIImage but I can not parse info without this functions.