### PR TITLE
Update project SWIFT_VERSION to 4.2 for Fix Swift 4.2 build error.

### DIFF
--- a/SwiftIconFont.xcodeproj/project.pbxproj
+++ b/SwiftIconFont.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -504,7 +504,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -558,7 +558,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = tr.sdev.SwiftIconFontTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -570,7 +570,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = tr.sdev.SwiftIconFontTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
What happened:
When using this library with CocoaPod, Swift Version of the build target is specified as 4.0 and an error occurs.
Approach:
Resolve Swift Version by specifying 4.2 for the entire project.